### PR TITLE
FreePBX 17 / PHP 8.2 compatibility patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,103 @@
 
 This is the Asternic CDR IssabelPBX and FPBX Module
 
+> **Community Fork Notice:** This fork (`carlswart/asternic-cdr-module`) contains **FreePBX 17 / PHP 8.2 compatibility patches** that are not yet merged upstream. If you are running FreePBX 14-16 with PHP 7, the original upstream version should work fine.
+
 ### What is this repository for? ###
 
 * Provides an alternative way to present CDR reports for Issabel and FPBX
 
-### How do I get set up? ###
+---
+
+## FreePBX 17 / PHP 8 Compatibility
+
+The upstream v1.6.6 was released in October 2024 but was not fully tested against FreePBX 17's default environment (PHP 8.2, Whoops error handler, PJSIP channels, and the new CDR recording pipeline). This fork applies 8 patches to fix fatal errors, warnings, and missing functionality.
+
+### What was broken
+
+| Symptom | FreePBX 17 Trigger |
+|---|---|
+| **Whoops crash on drill-down** | `Undefined array key "type"` in `getrecords` AJAX handler (PHP 8 E_WARNING → Whoops exception) |
+| **Missing recording icons on outgoing calls** | FreePBX 17 does not populate `recordingfile` in CDR for outgoing calls; only incoming |
+| **PDF export crash** | `Trying to access array offset on value of type null` in `PDF::Footer()` (missing locale globals) |
+| **PDF Combined report corruption** | Column mismatch: 12 data columns vs 11 header columns |
+| **FPDF fatal error** | `each()` function removed in PHP 8.1 |
+| **Distribution heatmap blank/Whoops** | Color index overflow when daily call count exceeds 7 |
+| **Unescaped superglobals in HTML** | `$_SERVER['REQUEST_URI']` and `$_REQUEST` echoed raw into forms and JS — XSS risk |
+| **Dead Flash code** | Legacy `swf_bar_old()` function referenced non-existent `.swf` files and triggered `html_entity_decode()` deprecation |
+
+### Patches applied
+
+| Patch | Commit | Files | Fix |
+|-------|--------|-------|-----|
+| **PATCH-001** | `6b54b0b` | `functions.inc.php` | Add null-coalescing defaults for `$_REQUEST['type']` and `$_REQUEST['display']` |
+| **PATCH-002** | `a09b4b6` | `functions.inc.php` | Add CEL session + disk `glob()` fallback for missing `recordingfile` paths |
+| **PATCH-003** | `6978961` | `functions.inc.php` | Guard `PDF::Footer()` against null `$lang` array |
+| **PATCH-004** | `4f4cbfd` | `functions.inc.php` + `page.asternic_cdr.php` | Fix Combined report PDF column mismatch |
+| **PATCH-005** | `75840ed` | `lib/fpdf.php` | Replace deprecated `each()` with `foreach()` |
+| **PATCH-006** | `e1e8507` | `page.asternic_cdr.php` | Cap color index in Distribution heatmap |
+| **PATCH-007** | `d779b70` | `functions.inc.php` + `page.asternic_cdr.php` | Escape `$_SERVER['REQUEST_URI']` and `$_REQUEST` loop output with `htmlspecialchars()` |
+| **PATCH-008** | `98d0882` | `functions.inc.php` | Remove dead Adobe Flash `swf_bar_old()` function |
+
+### Tested functionality
+
+- [x] Module loading / Module Admin
+- [x] Outgoing / Incoming / Combined report charts
+- [x] Drill-down detail table
+- [x] Recording icons — incoming & outgoing
+- [x] Call recording playback (Howler.js) — both directions
+- [x] Call recording download — both directions
+- [x] PDF export (all report types)
+- [x] CSV export
+- [x] Distribution hourly heatmap
+
+### Installation
+
+#### Method A: Direct tarball install (easiest)
+
+1. Download the latest release `.tgz` from [Releases](../../releases)
+2. Copy to your FreePBX server:
+   ```bash
+   scp asternic_cdr-1.6.6-fpbx17-patched.tgz root@freepbx:/tmp/
+   ```
+3. Install via FreePBX CLI:
+   ```bash
+   ssh root@freepbx
+   fwconsole ma delete asternic_cdr   # if older version exists
+   fwconsole ma installlocal /tmp/asternic_cdr-1.6.6-fpbx17-patched.tgz
+   fwconsole reload
+   ```
+
+#### Method B: Install from git
+
+```bash
+ssh root@freepbx
+cd /var/www/html/admin/modules
+git clone https://github.com/carlswart/asternic-cdr-module.git asternic_cdr
+fwconsole ma install asternic_cdr
+fwconsole reload
+```
+
+#### Method C: Manual file copy (for quick testing)
+
+If you already have the upstream module installed and only want to patch the changed files:
+
+```bash
+# From your dev machine
+cd asternic-cdr-module-1.6.6
+scp functions.inc.php root@freepbx:/var/www/html/admin/modules/asternic_cdr/
+scp page.asternic_cdr.php root@freepbx:/var/www/html/admin/modules/asternic_cdr/
+scp lib/fpdf.php root@freepbx:/var/www/html/admin/modules/asternic_cdr/lib/
+# No reload needed — PHP is interpreted per-request
+```
+
+### Upstream status
+
+These patches are intended to be submitted as a pull request to [asternic/asternic-cdr-module](https://github.com/asternic/asternic-cdr-module). Until merged, this fork serves as a community-maintained compatibility release.
+
+---
+
+### How do I get set up? (Original IssabelPBX instructions)
 
 Select the Security option from your Issabel menu and be sure to allow unembed access to Issabel PBX.
 Then go to http://your.server/admin to log into IssabelPBX directly, and from the module manager you 

--- a/functions.inc.php
+++ b/functions.inc.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 if(isset($_SERVER['PATH_INFO'])) {
     define("SELF",  substr($_SERVER['PHP_SELF'], 0, (strlen($_SERVER['PHP_SELF']) - @strlen($_SERVER['PATH_INFO']))));
@@ -106,40 +106,6 @@ type: 'bar',
 <?php
 }
 
-function swf_bar_old($values,$width,$height,$divid,$stack) {
-    global $config;
-
-    if ($stack==1) {
-        $chart = "images/barstack.swf";
-    } else {
-        $chart = "images/bar.swf";
-    }
-    $return = "<div id='$divid'>\n";
-    $return.= "</div>\n";
-    $values = html_entity_decode($values);
-    $return.= "<script type='text/javascript'>\n";
-    $return.='$(document).ready(function() {'."\n";
-
-    $variables = preg_split("/&/",$values);
-    if(isset($config['no_animation'][''])) {
-        $variables[] = "noanimate=1";
-    }
-
-    $return .= "var flashvars = {\n";
-    $param = Array();
-    foreach($variables as $deauna) {
-        $pedazos = preg_split("/=/",$deauna);
-        $param[]="'$pedazos[0]': '$pedazos[1]'";
-    }
-    $texti = implode(",\n",$param);
-    $return.=$texti;
-    $return.=" };\n";
-
-    $return.= "swfobject.embedSWF('$chart', '$divid', '$width', '$height', '9.0.0', '#336699', flashvars, {wmode:'transparent'});\n";
-    $return.= "});</script>\n";
-    echo $return;
-}
-
 function print_exports($header_pdf,$data_pdf,$width_pdf,$title_pdf,$cover_pdf,$appconfig) {
 
     $head_serial  = serialize($header_pdf);
@@ -153,11 +119,13 @@ function print_exports($header_pdf,$data_pdf,$width_pdf,$title_pdf,$cover_pdf,$a
     $title_serial = rawurlencode($title_serial);
     $cover_serial = rawurlencode($cover_serial);
 
-    $complete_self = $_SERVER['REQUEST_URI'];
+    $complete_self = htmlspecialchars($_SERVER['REQUEST_URI'], ENT_QUOTES, 'UTF-8');
     echo "<br/><form method='post' action='$complete_self'>\n";
     foreach($_REQUEST as $kkey=>$vval) {
         if(!is_array($vval)) {
-            echo "<input type='hidden' name='$kkey' value='".$vval."' />\n";
+            $safe_key = htmlspecialchars($kkey, ENT_QUOTES, 'UTF-8');
+            $safe_val = htmlspecialchars($vval, ENT_QUOTES, 'UTF-8');
+            echo "<input type='hidden' name='$safe_key' value='$safe_val' />\n";
         }
     }
     echo "<input type='hidden' name='action' value='export' />\n";
@@ -169,7 +137,7 @@ function print_exports($header_pdf,$data_pdf,$width_pdf,$title_pdf,$cover_pdf,$a
     echo "<a href='javascript:void()' class='info'><input type=image name='pdf' src='{$appconfig['relative_path']}asternic_pdf.gif' style='border:0;'><span>";
     echo _('Export to PDF');
     echo "</span></a>\n";
-    echo "<a href='javascript:void()' class='info'><input type=image name='csv' src='{$appconfig['relative_path']}asternic_excel.gif' style='border:0;'><span>"; 
+    echo "<a href='javascript:void()' class='info'><input type=image name='csv' src='{$appconfig['relative_path']}asternic_excel.gif' style='border:0;'><span>";
     echo _('Export to CSV/Excel');
     echo "</span></a>\n";
     echo "</form>";
@@ -185,7 +153,7 @@ function seconds2minutes($segundos) {
 
 function remove_quotes($argument) {
     return substr($argument,1,-1);
-}   
+}
 
 function asternic_download() {
     include("download.php");
@@ -232,8 +200,8 @@ function asternic_getrecords( $MYVARS ,$appconfig) {
         die($res->getMessage());
     }
 
-    $ftype = isset($_REQUEST['type']?$_REQUEST['type']:'');
-    $fdisplay = $_REQUEST['display'];
+    $ftype = $_REQUEST['type'] ?? 'tool';
+    $fdisplay = $_REQUEST['display'] ?? 'asternic_cdr';
     $ftab = $gtype;
 
     $cont=0;
@@ -294,11 +262,24 @@ function asternic_getrecords( $MYVARS ,$appconfig) {
             $uni = $row['uniqueid'];
             $uni = str_replace(".","",$uni);
 
-            if($row['recordingfile']<>"") {
-                if(!preg_match("/^\//",$row['recordingfile'])) {
-                    $actualfile = "$year/$month/$day/".$row['recordingfile'];
+            $actualfile = $row['recordingfile'] ?? '';
+            if($actualfile == "") {
+                // FreePBX 17 may not populate recordingfile for outgoing calls.
+                // Try CEL session data first, then fall back to disk search by uniqueid.
+                $celrec = $_SESSION['cel']['recordings'][$row['uniqueid']]['file'] ?? '';
+                if($celrec != "") {
+                    $actualfile = $celrec;
                 } else {
-                    $actualfile = $row['recordingfile'];
+                    $datepath = sprintf("/var/spool/asterisk/monitor/%04d/%02d/%02d/", $year, $month, $day);
+                    $matches = glob($datepath . "*" . $row['uniqueid'] . ".wav");
+                    if($matches && count($matches) > 0) {
+                        $actualfile = $matches[0];
+                    }
+                }
+            }
+            if($actualfile != "") {
+                if(!preg_match("/^\//",$actualfile)) {
+                    $actualfile = "$year/$month/$day/".$actualfile;
                 }
                 $detail[$campo].="<a href=\"javascript:void(0);\" onclick='javascript:playVmail(\"".$actualfile."\",\"play".$uni."\");'>";
                 $detail[$campo].="<div class='playicon' title='"._('Play')."' id='play".$uni."'  style='float:left;'>";
@@ -313,7 +294,7 @@ function asternic_getrecords( $MYVARS ,$appconfig) {
             }
             $detail[$campo].= "</td>\n";
             $detail[$campo].= "\n</tr>\n";
-        } 
+        }
     }
 
     echo "<table width='99%' cellpadding=3 cellspacing=3 border=0 id='table{$channel}' class='sortable'>\n";
@@ -331,7 +312,7 @@ function asternic_getrecords( $MYVARS ,$appconfig) {
     echo "<tbody>".$detail[$channel]."</tbody>\n";
     echo "</table>\n";
 
-    $complete_self = $_SERVER['REQUEST_URI'];
+    $complete_self = htmlspecialchars($_SERVER['REQUEST_URI'], ENT_QUOTES, 'UTF-8');
     echo "<form id='downloadform' method='get' action='$complete_self'><input type=hidden name='file' id='downloadfile' value=''><input type=hidden name='action' value='download'><input type='hidden' name='type' id='dtype' value=''><input type='hidden' id='idisplay' name='display' value=''> <input type='hidden' id='itab' name='tab' value=''></form>";
 
 }
@@ -350,7 +331,8 @@ class PDF extends FPDF
         //Select Arial italic 8
         $this->SetFont('Arial','I',8);
         //Print centered page number
-        $this->Cell(0,10,$lang["$language"]['page'].' '.$this->PageNo(),0,0,'C');
+        $pageText = (isset($lang[$language]['page']) ? $lang[$language]['page'] : 'Page') . ' ' . $this->PageNo();
+        $this->Cell(0,10,$pageText,0,0,'C');
     }
 
     function Cover($cover) {
@@ -398,7 +380,9 @@ class PDF extends FPDF
         foreach($data as $row) {
             $contador=0;
             foreach($row as $valor) {
-                $this->Cell($w[$contador],6,$valor,'LR',0,'C',$fill);
+                if(isset($w[$contador])) {
+                    $this->Cell($w[$contador],6,$valor,'LR',0,'C',$fill);
+                }
                 $contador++;
             }
             $this->Ln();

--- a/functions.inc.php
+++ b/functions.inc.php
@@ -285,7 +285,9 @@ function asternic_getrecords( $MYVARS ,$appconfig) {
                 $detail[$campo].="<div class='playicon' title='"._('Play')."' id='play".$uni."'  style='float:left;'>";
                 $detail[$campo].="<img src='images/blank.gif' alt='pixel' height='16' width='16' border='0'>";
                 $detail[$campo].="</div></a>";
-                $detail[$campo].="<a href=\"javascript:void(0); return false;\" onclick='javascript:downloadVmail(\"".$actualfile."\",\"play".$uni."\",\"$ftype\",\"$fdisplay\",\"$ftab\"); return false;'>";
+                $safe_ftype = htmlspecialchars($ftype, ENT_QUOTES, 'UTF-8');
+                $safe_fdisplay = htmlspecialchars($fdisplay, ENT_QUOTES, 'UTF-8');
+                $detail[$campo].="<a href=\"javascript:void(0); return false;\" onclick='javascript:downloadVmail(\"".$actualfile."\",\"play".$uni."\",\"$safe_ftype\",\"$safe_fdisplay\",\"$ftab\"); return false;'>";
                 $detail[$campo].="<div class='downicon' title='"._('Download')."' id='dload".$uni."'  style='float:left;'>";
                 $detail[$campo].="<img src='images/blank.gif' alt='pixel' height='16' width='16' border='0'>";
                 $detail[$campo].="</div></a>";
@@ -331,7 +333,7 @@ class PDF extends FPDF
         //Select Arial italic 8
         $this->SetFont('Arial','I',8);
         //Print centered page number
-        $pageText = (isset($lang[$language]['page']) ? $lang[$language]['page'] : 'Page') . ' ' . $this->PageNo();
+        $pageText = (isset($lang[$language]) ? ($lang[$language]['page'] ?? 'Page') : 'Page') . ' ' . $this->PageNo();
         $this->Cell(0,10,$pageText,0,0,'C');
     }
 

--- a/lib/fpdf.php
+++ b/lib/fpdf.php
@@ -1258,8 +1258,7 @@ function _putfonts()
 function _putimages()
 {
 	$filter=($this->compress) ? '/Filter /FlateDecode ' : '';
-	reset($this->images);
-	while(list($file,$info)=each($this->images))
+	foreach($this->images as $file=>$info)
 	{
 		$this->_newobj();
 		$this->images[$file]['n']=$this->n;

--- a/page.asternic_cdr.php
+++ b/page.asternic_cdr.php
@@ -459,6 +459,7 @@ function asternic_distribution($appconfig) {
                     if(!isset($num[$chann][$date][$hour])) { $num[$chann][$date][$hour]=0;}
                     $numcolor = intval(($dur[$chann][$date][$hour]/60)/10);
                     if((intval($dur[$chann][$date][$hour]/60))==0) { $numcolor=6; }
+                    if($numcolor > 6) { $numcolor = 6; }
                     $minutes_this_hour = intval($dur[$chann][$date][$hour]/60);
                     $total_day+=$minutes_this_hour;
                     echo "<td bgcolor='$colorete[$numcolor]'>$minutes_this_hour</td>";
@@ -939,6 +940,7 @@ if($total_calls>0) {
                                _('Calls'),
                                _('Incoming'),
                                _('Outgoing'),
+                               _('Completed'),
                                _('Missed'),
                                _('Percent'),
                                _('Bill secs'),
@@ -947,7 +949,7 @@ if($total_calls>0) {
                                _('Ring Time'),
                                _('Avg. Ring')
             );
-            $width_pdf=array(35,15,10,10,15,15,25,20,20,20,20);
+            $width_pdf=array(35,15,10,10,15,15,15,25,20,20,20,20);
             $title_pdf=$rep_title;
 
            $contador=0;
@@ -997,7 +999,7 @@ if($total_calls>0) {
                 }
                 $percent_missed = number_format($percent_missed,0)." "._('%');
 
-                $complete_self = $_SERVER['REQUEST_URI'];
+                $complete_self = htmlspecialchars($_SERVER['REQUEST_URI'], ENT_QUOTES, 'UTF-8');
                 echo "<tr $odd>\n";
 
                 echo "<td style='text-align: left;'><a style='cursor:pointer;' onclick=\"javascript:getRecords('$chan','${appconfig['start']}','${appconfig['end']}','combined','$complete_self');\">";
@@ -1011,12 +1013,8 @@ if($total_calls>0) {
                 echo "<td>".$missed[$idx][$chan]."</td>\n";
                 echo "<td align=right>".$percent_missed."</td>\n";
                 echo "<td>$bill_print</td>\n";
-                if($total_bill>0) {
-                    $percentage_bill = $val * 100 / $total_bill;
-                    $percentage_bill = number_format($percentage_bill,2);
-                } else {
-                    $percentage_bill = "0";
-                }
+                $percentage_bill = $val * 100 / $total_bill;
+                $percentage_bill = number_format($percentage_bill,2);
                 echo "<td>$percentage_bill "._('%')."</td>\n";
                 echo "<td>$avg_duration_print</td>\n";
                 echo "<td>$ring_time "._('secs')."</td>\n";
@@ -1407,7 +1405,7 @@ if($total_calls>0) {
                 }
                 $percent_missed = number_format($percent_missed,0)." "._('%');
 
-                $complete_self = $_SERVER['REQUEST_URI'];
+                $complete_self = htmlspecialchars($_SERVER['REQUEST_URI'], ENT_QUOTES, 'UTF-8');
                 //$complete_self .= "&chan=$chan&startd=$start&endd=$end&direction=$typerecord";
                 echo "<tr $odd>\n";
 

--- a/page.asternic_cdr.php
+++ b/page.asternic_cdr.php
@@ -489,6 +489,7 @@ function asternic_distribution($appconfig) {
                 // echo "$hour ".intval($dur[$chann][$date][$hour]/60)." - ".$num[$chann][$date][$hour]."<BR>" ;
                 $numcolor = intval(($dur[$chann][$date][$hour]/60)/10);
                 if((intval($dur[$chann][$date][$hour]/60))==0) { $numcolor=6; }
+                if($numcolor > 6) { $numcolor = 6; }
                 $minutes_this_hour = intval($dur[$chann][$date][$hour]/60);
                 $total_day+=$minutes_this_hour;
                 echo "<td bgcolor='$colorete[$numcolor]'>$minutes_this_hour</td>";
@@ -1013,8 +1014,12 @@ if($total_calls>0) {
                 echo "<td>".$missed[$idx][$chan]."</td>\n";
                 echo "<td align=right>".$percent_missed."</td>\n";
                 echo "<td>$bill_print</td>\n";
-                $percentage_bill = $val * 100 / $total_bill;
-                $percentage_bill = number_format($percentage_bill,2);
+                if($total_bill>0) {
+                    $percentage_bill = $val * 100 / $total_bill;
+                    $percentage_bill = number_format($percentage_bill,2);
+                } else {
+                    $percentage_bill = "0";
+                }
                 echo "<td>$percentage_bill "._('%')."</td>\n";
                 echo "<td>$avg_duration_print</td>\n";
                 echo "<td>$ring_time "._('secs')."</td>\n";


### PR DESCRIPTION
This PR applies 8 patches to make Asternic CDR Reports v1.6.6 compatible with FreePBX 17 (PHP 8.2, Whoops error handler, PJSIP channels, and the new CDR recording pipeline).

# Background

FreePBX 17 ships with PHP 8.x and the Whoops error handler, which converts E_WARNING into exceptions. The upstream v1.6.6 code was written for PHP 5/7 where missing array keys silently returned null. This causes hard crashes on multiple
features.

Additionally, FreePBX 17's CDR backend does not populate recordingfile for outgoing calls, breaking the play/download icons that the module relies on.

# Patches included

| Patch │ Commit │What it fixes │
| ----- | --- | --- |
│ PATCH-001 │ 6b54b0b │ $_REQUEST['type'] / $_REQUEST['display'] undefined in getrecords AJAX handler        │
│ PATCH-002 │ a09b4b6 │ Missing recording icons for outgoing calls — adds CEL session + disk glob() fallback │
│ PATCH-003 │ 6978961 │ PDF Footer() crash on null $lang array                                               │
│ PATCH-004 │ 4f4cbfd │ PDF Combined report column mismatch (12 data columns vs 11 headers)                  │
│ PATCH-005 │ 75840ed │ Replace deprecated each() with foreach() in bundled FPDF                             │
│ PATCH-006 │ e1e8507 │ Distribution heatmap color index overflow ($colorete has only 7 elements)            │
│ PATCH-007 │ d779b70 │ Escape unfiltered $_SERVER['REQUEST_URI'] and $_REQUEST output in HTML/JS            │
│ PATCH-008 │ 98d0882 │ Remove dead Adobe Flash swf_bar_old() function (no callers, no SWF assets)           │

# Testing performed

All functionality was tested on a live FreePBX 17.0.28 installation:
- Module loading / Module Admin
- Outgoing / Incoming / Combined report charts
- Drill-down detail table
- Recording icons (incoming & outgoing)
- Call recording playback (Howler.js)
- Call recording download
- PDF export (all report types)
- CSV export
- Distribution hourly heatmap

# Backward compatibility

These changes are backward-compatible with PHP 7 / FreePBX 14-16:
- Null coalescing (??) works on PHP 7.0+
- htmlspecialchars() with explicit encoding is safe on all PHP versions
- foreach() replacing each() is valid on all PHP versions
- The removed swf_bar_old() had zero callers

# Documentation

The README has been updated with a FreePBX 17 Compatibility section explaining the fixes and installation methods.

---
Thank you for maintaining this module. Let me know if you would like any changes before merging.
